### PR TITLE
Fixed unresolved passport callbacks

### DIFF
--- a/_remake/lib/init-user-accounts.js
+++ b/_remake/lib/init-user-accounts.js
@@ -38,7 +38,9 @@ function initUserAccounts ({ app }) {
       cb(null, currentUser);
       return;
     } catch (err) {
-      showConsoleError("Error: Passport db error", err);
+      let msg = "Error: Passport db error";
+      showConsoleError(msg + ':', err);
+      cb(msg, null);
     }
   }));
 
@@ -57,7 +59,11 @@ function initUserAccounts ({ app }) {
 
     if (currentUser) {
       cb(null, currentUser);
+      return;
     }
+    let msg = "Error: Passport deserialize error";
+    showConsoleError(msg);
+    cb(msg, null);
   });
 
   app.post(/(\/app_[a-z]+[a-z0-9-]*)?\/user\/signup/, async function(req, res) {


### PR DESCRIPTION
Passport requires you resolve even on errors.  I discovered these missing callback calls while I was working on electron support for remake (which is almost done).  I tried my best to match how you were handling errors with logging.  This seems to fix it.