### PR TITLE
Allow edit prompt opening on new item creation

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,16 @@
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": false,
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "printWidth": 100,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "endOfLine": "lf"
+}

--- a/_remake/client-side/inputjs/addingItemEventListener.js
+++ b/_remake/client-side/inputjs/addingItemEventListener.js
@@ -1,21 +1,21 @@
 import { $ } from '../queryjs';
 import { getAttributeValueAsArray } from '../parse-data-attributes';
 import { ajaxPost } from '../hummingbird/lib/ajax';
-import { findNearest, onAttributeEvent} from '../hummingbird/lib/dom';
+import { findNearest, onAttributeEvent } from '../hummingbird/lib/dom';
 import { isStringANumber } from '../hummingbird/lib/string';
 import { showError } from '../common/show-error';
 import { callSaveFunction } from './onSave';
-import { callOnAddItemCallbacks } from './callbacks';
+import { callOnAddItemCallbacks, openEditCallback } from './callbacks';
 import optionsData from './optionsData';
 const camelCase = require('lodash/camelCase');
 
-function _defaultAddItemCallback ({templateName, listElem, whereToInsert, openEditPrompt}) {
+function _defaultAddItemCallback({ templateName, listElem, whereToInsert, openPopup }) {
   // pass the template name into an endpoint and get the resulting html back
-  ajaxPost("/new", {templateName}, function (ajaxResponse) {
-    let {htmlString, success} = ajaxResponse;
+  ajaxPost('/new', { templateName }, function(ajaxResponse) {
+    let { htmlString, success } = ajaxResponse;
 
     if (!success) {
-      callOnAddItemCallbacks({success: false, templateName, ajaxResponse});
+      callOnAddItemCallbacks({ success: false, templateName, ajaxResponse });
       return;
     }
 
@@ -30,36 +30,62 @@ function _defaultAddItemCallback ({templateName, listElem, whereToInsert, openEd
     // save needs to be called on the list element, not the item, so it doesn't try to save to a non-existent id
     callSaveFunction(listElem);
 
-    let itemElem = whereToInsert === "afterbegin" ? listElem.firstElementChild : listElem.lastElementChild;
+    let itemElem =
+      whereToInsert === 'afterbegin' ? listElem.firstElementChild : listElem.lastElementChild;
 
-    // Click new itemElem so that it opens up the edit prompt
-    if (openEditPrompt) itemElem.click();
-    callOnAddItemCallbacks({success: true, listElem, itemElem, templateName, ajaxResponse});
+    if (openPopup) {
+      const attributeNames = itemElem.getAttributeNames();
+      let editAttribute = null;
+
+      // We need to find the full name of the edit:item attribute so
+      // That we can pass it into the matchingAttribute property
+      // We can't just getAttribute since edit:item's item can vary
+      for (const attributeName of attributeNames) {
+        if (attributeName.startsWith('edit:')) {
+          editAttribute = attributeName;
+          break;
+        }
+      }
+
+      // Brings up the edit popup
+      // We need to pass a matches object because it technically relies on the hummingbird return for the
+      // callback for onAttributeEvent()
+      openEditCallback([
+        {
+          matchingElement: itemElem,
+          matchingAttribute: editAttribute,
+          value: '',
+          eventType: 'click',
+          mathcingPartialAttributeString: 'edit:',
+        },
+      ]);
+    }
+
+    callOnAddItemCallbacks({ success: true, listElem, itemElem, templateName, ajaxResponse });
   });
 }
 
-export default function () {
+export default function() {
   onAttributeEvent({
-    eventTypes: ["click"],
-    partialAttributeStrings: ["new:"],
-    filterOutElemsInsideAncestor: "[disable-events]",
-    callback: ({matchingElement, matchingAttribute}) => {
-      let templateName = camelCase(matchingAttribute.substring("new:".length));
+    eventTypes: ['click'],
+    partialAttributeStrings: ['new:'],
+    filterOutElemsInsideAncestor: '[disable-events]',
+    callback: ({ matchingElement, matchingAttribute }) => {
+      let templateName = camelCase(matchingAttribute.substring('new:'.length));
       // possible values in argArray: top/bottom or some selector
       let argArray = getAttributeValueAsArray(matchingElement, matchingAttribute);
-      let position = argArray.indexOf("top") !== -1 ? "top" : "bottom";
-      let whereToInsert = position === "top" ? "afterbegin" : "beforeend";
-      let selector = argArray.find(arg => arg !== "top" && arg !== "bottom") || "[array]";
+      let position = argArray.indexOf('top') !== -1 ? 'top' : 'bottom';
+      let openPopup = argArray.indexOf('open-popup') !== -1;
+      let whereToInsert = position === 'top' ? 'afterbegin' : 'beforeend';
+      let selector = argArray.find((arg) => arg !== 'top' && arg !== 'bottom') || '[array]';
       // find the nearest element matching the selector (searching through ancestors consecutively)
-      let listElem = findNearest({elem: matchingElement, selector});
-      // Automatically open edit prompt if a single `edit` attr is present
-      let openEditPrompt = matchingElement.hasAttribute('edit');
+      let listElem = findNearest({ elem: matchingElement, selector });
 
       if (!optionsData._defaultAddItemCallback) {
-        _defaultAddItemCallback({templateName, listElem, whereToInsert, openEditPrompt});
+        _defaultAddItemCallback({ templateName, listElem, whereToInsert, openPopup });
       } else {
-        optionsData._defaultAddItemCallback({templateName, listElem, whereToInsert, openEditPrompt});
+        optionsData._defaultAddItemCallback({ templateName, listElem, whereToInsert, openPopup });
       }
-    }
+    },
   });
 }

--- a/_remake/client-side/inputjs/addingItemEventListener.js
+++ b/_remake/client-side/inputjs/addingItemEventListener.js
@@ -58,7 +58,7 @@ export default function () {
       if (!optionsData._defaultAddItemCallback) {
         _defaultAddItemCallback({templateName, listElem, whereToInsert, openEditPrompt});
       } else {
-        optionsData._defaultAddItemCallback({templateName, listElem, openEditPrompt});
+        optionsData._defaultAddItemCallback({templateName, listElem, whereToInsert, openEditPrompt});
       }
     }
   });

--- a/_remake/client-side/inputjs/addingItemEventListener.js
+++ b/_remake/client-side/inputjs/addingItemEventListener.js
@@ -1,21 +1,22 @@
-import { $ } from '../queryjs';
-import { getAttributeValueAsArray } from '../parse-data-attributes';
-import { ajaxPost } from '../hummingbird/lib/ajax';
-import { findNearest, onAttributeEvent } from '../hummingbird/lib/dom';
-import { isStringANumber } from '../hummingbird/lib/string';
-import { showError } from '../common/show-error';
-import { callSaveFunction } from './onSave';
-import { callOnAddItemCallbacks, openEditCallback } from './callbacks';
-import optionsData from './optionsData';
-const camelCase = require('lodash/camelCase');
+import {$} from "../queryjs";
+import {getAttributeValueAsArray} from "../parse-data-attributes";
+import {ajaxPost} from "../hummingbird/lib/ajax";
+import {findNearest, onAttributeEvent} from "../hummingbird/lib/dom";
+import {isStringANumber} from "../hummingbird/lib/string";
+import {showError} from "../common/show-error";
+import {callSaveFunction} from "./onSave";
+import {callOnAddItemCallbacks} from "./callbacks";
+import {openEditCallback} from "./editableAttribute.js";
+import optionsData from "./optionsData";
+const camelCase = require("lodash/camelCase");
 
-function _defaultAddItemCallback({ templateName, listElem, whereToInsert, openPopup }) {
+function _defaultAddItemCallback({templateName, listElem, whereToInsert, openPopup}) {
   // pass the template name into an endpoint and get the resulting html back
-  ajaxPost('/new', { templateName }, function(ajaxResponse) {
-    let { htmlString, success } = ajaxResponse;
+  ajaxPost("/new", {templateName}, function(ajaxResponse) {
+    let {htmlString, success} = ajaxResponse;
 
     if (!success) {
-      callOnAddItemCallbacks({ success: false, templateName, ajaxResponse });
+      callOnAddItemCallbacks({success: false, templateName, ajaxResponse});
       return;
     }
 
@@ -31,60 +32,61 @@ function _defaultAddItemCallback({ templateName, listElem, whereToInsert, openPo
     callSaveFunction(listElem);
 
     let itemElem =
-      whereToInsert === 'afterbegin' ? listElem.firstElementChild : listElem.lastElementChild;
+      whereToInsert === "afterbegin" ? listElem.firstElementChild : listElem.lastElementChild;
 
     if (openPopup) {
       const attributeNames = itemElem.getAttributeNames();
-      let editAttribute = null;
 
-      // We need to find the full name of the edit:item attribute so
+      // We need to find the full name of the edit:item attribute(s) so
       // That we can pass it into the matchingAttribute property
       // We can't just getAttribute since edit:item's item can vary
-      for (const attributeName of attributeNames) {
-        if (attributeName.startsWith('edit:')) {
-          editAttribute = attributeName;
-          break;
-        }
-      }
+      let editAttributes = attributeNames.filter(name => name.startsWith("edit:"));
 
-      // Brings up the edit popup
-      // We need to pass a matches object because it technically relies on the hummingbird return for the
-      // callback for onAttributeEvent()
-      openEditCallback([
-        {
+      // Only open if there are edit attributes
+      if (editAttributes.length > 0) {
+        // We need to create a matches object because it technically relies
+        // on the hummingbird return for the callback for onAttributeEvent()
+        const defaultMatchObject = {
           matchingElement: itemElem,
-          matchingAttribute: editAttribute,
-          value: '',
-          eventType: 'click',
-          mathcingPartialAttributeString: 'edit:',
-        },
-      ]);
+          value: "",
+          eventType: "click",
+          matchingPartialAttributeString: "edit:",
+        };
+
+        const matches = editAttributes(attrName => ({
+          ...defaultMatchObject,
+          matchingAttribute: attrName,
+        }));
+
+        // Brings up the edit popup
+        openEditCallback(matches);
+      }
     }
 
-    callOnAddItemCallbacks({ success: true, listElem, itemElem, templateName, ajaxResponse });
+    callOnAddItemCallbacks({success: true, listElem, itemElem, templateName, ajaxResponse});
   });
 }
 
 export default function() {
   onAttributeEvent({
-    eventTypes: ['click'],
-    partialAttributeStrings: ['new:'],
-    filterOutElemsInsideAncestor: '[disable-events]',
-    callback: ({ matchingElement, matchingAttribute }) => {
-      let templateName = camelCase(matchingAttribute.substring('new:'.length));
+    eventTypes: ["click"],
+    partialAttributeStrings: ["new:"],
+    filterOutElemsInsideAncestor: "[disable-events]",
+    callback: ({matchingElement, matchingAttribute}) => {
+      let templateName = camelCase(matchingAttribute.substring("new:".length));
       // possible values in argArray: top/bottom or some selector
       let argArray = getAttributeValueAsArray(matchingElement, matchingAttribute);
-      let position = argArray.indexOf('top') !== -1 ? 'top' : 'bottom';
-      let openPopup = argArray.indexOf('open-popup') !== -1;
-      let whereToInsert = position === 'top' ? 'afterbegin' : 'beforeend';
-      let selector = argArray.find((arg) => arg !== 'top' && arg !== 'bottom') || '[array]';
+      let position = argArray.indexOf("top") !== -1 ? "top" : "bottom";
+      let openPopup = argArray.indexOf("open-popup") !== -1;
+      let whereToInsert = position === "top" ? "afterbegin" : "beforeend";
+      let selector = argArray.find(arg => arg !== "top" && arg !== "bottom") || "[array]";
       // find the nearest element matching the selector (searching through ancestors consecutively)
-      let listElem = findNearest({ elem: matchingElement, selector });
+      let listElem = findNearest({elem: matchingElement, selector});
 
       if (!optionsData._defaultAddItemCallback) {
-        _defaultAddItemCallback({ templateName, listElem, whereToInsert, openPopup });
+        _defaultAddItemCallback({templateName, listElem, whereToInsert, openPopup});
       } else {
-        optionsData._defaultAddItemCallback({ templateName, listElem, whereToInsert, openPopup });
+        optionsData._defaultAddItemCallback({templateName, listElem, whereToInsert, openPopup});
       }
     },
   });

--- a/_remake/client-side/inputjs/callbacks.js
+++ b/_remake/client-side/inputjs/callbacks.js
@@ -1,4 +1,4 @@
-import optionsData from './optionsData';
+import optionsData from "./optionsData";
 
 // Called by user
 
@@ -29,145 +29,25 @@ export function onSync(cb) {
 // Called by framework
 
 export function callOnSaveCallbacks(...args) {
-  optionsData.onSaveCallbacks.forEach((cb) => cb(...args));
+  optionsData.onSaveCallbacks.forEach(cb => cb(...args));
 }
 
 export function callOnFileUploadCallbacks(...args) {
-  optionsData.onFileUploadCallbacks.forEach((cb) => cb(...args));
+  optionsData.onFileUploadCallbacks.forEach(cb => cb(...args));
 }
 
 export function callOnFileUploadProgressCallbacks(...args) {
-  optionsData.onFileUploadProgressCallbacks.forEach((cb) => cb(...args));
+  optionsData.onFileUploadProgressCallbacks.forEach(cb => cb(...args));
 }
 
 export function callOnAddItemCallbacks(...args) {
-  optionsData.onAddItemCallbacks.forEach((cb) => cb(...args));
+  optionsData.onAddItemCallbacks.forEach(cb => cb(...args));
 }
 
 export function callOnRemoveItemCallbacks(...args) {
-  optionsData.onRemoveItemCallbacks.forEach((cb) => cb(...args));
+  optionsData.onRemoveItemCallbacks.forEach(cb => cb(...args));
 }
 
 export function callOnSyncCallbacks(...args) {
-  optionsData.onSyncCallbacks.forEach((cb) => cb(...args));
+  optionsData.onSyncCallbacks.forEach(cb => cb(...args));
 }
-
-// USAGE EXAMPLES:
-// edit:example-key
-// edit:example-key:text
-// edit:example-key:textarea
-export const openEditCallback = (matches) => {
-  // matches: [{eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
-
-  // editableConfig: [{keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
-  let editableConfig = matches.map(
-    ({ eventType, matchingElement, matchingAttribute, matchingPartialAttributeString }) => {
-    let attributeParts = matchingAttribute.split(':');
-      // attributeParts could be:
-      // ["edit", "example-key"]
-      // ["edit", "example-key", "without-remove"]
-      // ["edit", "example-key", "textarea", "without-remove"]
-      // -> first two items are requireed, the last two are optional
-      let [_, keyName, ...otherOptions] = attributeParts;
-
-      let validRemoveOptions = ['with-remove', 'without-remove', 'with-erase'];
-      let validFormTypes = ['text', 'textarea'];
-
-      // if `otherOptions` includes includes a valid remove option, use that. Otherwise, use default value.
-      let removeOption =
-        validRemoveOptions.find((str) => otherOptions.includes(str)) || 'with-remove';
-      // if `otherOptions` includes includes a valid form type option, use that. Otherwise, use default value.
-      let formType = validFormTypes.find((str) => otherOptions.includes(str)) || 'text';
-
-      return {
-        keyName,
-        formType,
-        removeOption,
-        eventType,
-        matchingElement,
-        matchingAttribute,
-        matchingPartialAttributeString,
-      };
-    }
-  );
-
-  // get first matching element for positioning popover
-  let firstMatch = editableConfig[0];
-  let firstMatchElem = firstMatch.matchingElement;
-  let firstMatchKeyName = firstMatch.keyName;
-  let firstMatchRemoveOption = firstMatch.removeOption;
-  let firstMatchTargetElem = getClosestElemWithKey({
-    elem: firstMatchElem,
-    keyName: firstMatchKeyName,
-  });
-
-  if (!firstMatchElem || !firstMatchKeyName || !firstMatchTargetElem) {
-    showError(
-      `Problem with the 'edit:' attribute on one of these elements:`,
-      matches.map((m) => m.matchingElement)
-    );
-    return;
-  }
-
-  let editablePopoverElem = document.querySelector('.remake-edit');
-
-  // reset popover: remove old keys
-  removeObjectKeysFromElem({ elem: editablePopoverElem });
-
-  // open popover
-  let hasRemove = firstMatchRemoveOption === 'with-remove';
-  let hasErase = firstMatchRemoveOption === 'with-erase';
-  editablePopoverElem.setAttribute(`temporary:key:remake-edit-popover`, '');
-  editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-remove`, '');
-  editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-erase`, '');
-  setValueForKeyName({ elem: editablePopoverElem, keyName: 'remake-edit-popover', value: 'on' });
-  setValueForKeyName({
-    elem: editablePopoverElem,
-    keyName: 'remake-edit-option-has-remove',
-    value: hasRemove ? 'on' : 'off',
-  });
-  setValueForKeyName({
-    elem: editablePopoverElem,
-    keyName: 'remake-edit-option-has-erase',
-    value: hasErase ? 'on' : 'off',
-  });
-
-  // keep track of the source of the data on the popover element
-  $.data(editablePopoverElem, 'source', firstMatchTargetElem);
-
-  // add object keys for storing data that's being edited in the popover
-  addObjectKeysToElem({ elem: editablePopoverElem, config: editableConfig });
-
-  // sync data from the page into the popover
-  syncDataNextTick({
-    sourceElement: firstMatchElem,
-    targetElement: editablePopoverElem,
-    keyNames: editableConfig.map((obj) => obj.keyName),
-    shouldSyncIntoUpdateElems: true,
-  });
-
-  // render html inside the edit popover
-  let remakeEditAreasElem = editablePopoverElem.querySelector('.remake-edit__edit-areas');
-  remakeEditAreasElem.innerHTML = generateRemakeEditAreas({ config: editableConfig });
-
-  // copy the layout
-  copyLayout({
-    sourceElem: firstMatchElem,
-    targetElem: editablePopoverElem,
-    dimensionsName: 'width',
-    xOffset: 0,
-    yOffset: 0,
-  });
-
-  // autosize textareas -- not sure why or even if this needs to be in a setTimeout
-  setTimeout(function() {
-    let textareas = Array.from(editablePopoverElem.querySelectorAll('textarea'));
-    textareas.forEach((el) => autosize(el));
-  });
-
-  // focus first focusable element
-  let firstFormInput = editablePopoverElem.querySelector('textarea, input');
-  if (firstFormInput) {
-    firstFormInput.focus();
-  }
-};

--- a/_remake/client-side/inputjs/callbacks.js
+++ b/_remake/client-side/inputjs/callbacks.js
@@ -2,60 +2,172 @@ import optionsData from './optionsData';
 
 // Called by user
 
-export function onSave (cb) {
+export function onSave(cb) {
   optionsData.onSaveCallbacks.push(cb);
 }
 
-export function onFileUpload (cb) {
+export function onFileUpload(cb) {
   optionsData.onFileUploadCallbacks.push(cb);
 }
 
-export function onFileUploadProgress (cb) {
+export function onFileUploadProgress(cb) {
   optionsData.onFileUploadProgressCallbacks.push(cb);
 }
 
-export function onAddItem (cb) {
+export function onAddItem(cb) {
   optionsData.onAddItemCallbacks.push(cb);
 }
 
-export function onRemoveItem (cb) {
+export function onRemoveItem(cb) {
   optionsData.onRemoveItemCallbacks.push(cb);
 }
 
-export function onSync (cb) {
+export function onSync(cb) {
   optionsData.onSyncCallbacks.push(cb);
 }
 
 // Called by framework
 
-export function callOnSaveCallbacks (...args) {
-  optionsData.onSaveCallbacks.forEach(cb => cb(...args));
+export function callOnSaveCallbacks(...args) {
+  optionsData.onSaveCallbacks.forEach((cb) => cb(...args));
 }
 
-export function callOnFileUploadCallbacks (...args) {
-  optionsData.onFileUploadCallbacks.forEach(cb => cb(...args));
+export function callOnFileUploadCallbacks(...args) {
+  optionsData.onFileUploadCallbacks.forEach((cb) => cb(...args));
 }
 
-export function callOnFileUploadProgressCallbacks (...args) {
-  optionsData.onFileUploadProgressCallbacks.forEach(cb => cb(...args));
+export function callOnFileUploadProgressCallbacks(...args) {
+  optionsData.onFileUploadProgressCallbacks.forEach((cb) => cb(...args));
 }
 
-export function callOnAddItemCallbacks (...args) {
-  optionsData.onAddItemCallbacks.forEach(cb => cb(...args));
+export function callOnAddItemCallbacks(...args) {
+  optionsData.onAddItemCallbacks.forEach((cb) => cb(...args));
 }
 
-export function callOnRemoveItemCallbacks (...args) {
-  optionsData.onRemoveItemCallbacks.forEach(cb => cb(...args));
+export function callOnRemoveItemCallbacks(...args) {
+  optionsData.onRemoveItemCallbacks.forEach((cb) => cb(...args));
 }
 
-export function callOnSyncCallbacks (...args) {
-  optionsData.onSyncCallbacks.forEach(cb => cb(...args));
+export function callOnSyncCallbacks(...args) {
+  optionsData.onSyncCallbacks.forEach((cb) => cb(...args));
 }
 
+// USAGE EXAMPLES:
+// edit:example-key
+// edit:example-key:text
+// edit:example-key:textarea
+export const openEditCallback = (matches) => {
+  // matches: [{eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
 
+  // editableConfig: [{keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
+  let editableConfig = matches.map(
+    ({ eventType, matchingElement, matchingAttribute, matchingPartialAttributeString }) => {
+    let attributeParts = matchingAttribute.split(':');
+      // attributeParts could be:
+      // ["edit", "example-key"]
+      // ["edit", "example-key", "without-remove"]
+      // ["edit", "example-key", "textarea", "without-remove"]
+      // -> first two items are requireed, the last two are optional
+      let [_, keyName, ...otherOptions] = attributeParts;
 
+      let validRemoveOptions = ['with-remove', 'without-remove', 'with-erase'];
+      let validFormTypes = ['text', 'textarea'];
 
+      // if `otherOptions` includes includes a valid remove option, use that. Otherwise, use default value.
+      let removeOption =
+        validRemoveOptions.find((str) => otherOptions.includes(str)) || 'with-remove';
+      // if `otherOptions` includes includes a valid form type option, use that. Otherwise, use default value.
+      let formType = validFormTypes.find((str) => otherOptions.includes(str)) || 'text';
 
+      return {
+        keyName,
+        formType,
+        removeOption,
+        eventType,
+        matchingElement,
+        matchingAttribute,
+        matchingPartialAttributeString,
+      };
+    }
+  );
 
+  // get first matching element for positioning popover
+  let firstMatch = editableConfig[0];
+  let firstMatchElem = firstMatch.matchingElement;
+  let firstMatchKeyName = firstMatch.keyName;
+  let firstMatchRemoveOption = firstMatch.removeOption;
+  let firstMatchTargetElem = getClosestElemWithKey({
+    elem: firstMatchElem,
+    keyName: firstMatchKeyName,
+  });
 
+  if (!firstMatchElem || !firstMatchKeyName || !firstMatchTargetElem) {
+    showError(
+      `Problem with the 'edit:' attribute on one of these elements:`,
+      matches.map((m) => m.matchingElement)
+    );
+    return;
+  }
 
+  let editablePopoverElem = document.querySelector('.remake-edit');
+
+  // reset popover: remove old keys
+  removeObjectKeysFromElem({ elem: editablePopoverElem });
+
+  // open popover
+  let hasRemove = firstMatchRemoveOption === 'with-remove';
+  let hasErase = firstMatchRemoveOption === 'with-erase';
+  editablePopoverElem.setAttribute(`temporary:key:remake-edit-popover`, '');
+  editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-remove`, '');
+  editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-erase`, '');
+  setValueForKeyName({ elem: editablePopoverElem, keyName: 'remake-edit-popover', value: 'on' });
+  setValueForKeyName({
+    elem: editablePopoverElem,
+    keyName: 'remake-edit-option-has-remove',
+    value: hasRemove ? 'on' : 'off',
+  });
+  setValueForKeyName({
+    elem: editablePopoverElem,
+    keyName: 'remake-edit-option-has-erase',
+    value: hasErase ? 'on' : 'off',
+  });
+
+  // keep track of the source of the data on the popover element
+  $.data(editablePopoverElem, 'source', firstMatchTargetElem);
+
+  // add object keys for storing data that's being edited in the popover
+  addObjectKeysToElem({ elem: editablePopoverElem, config: editableConfig });
+
+  // sync data from the page into the popover
+  syncDataNextTick({
+    sourceElement: firstMatchElem,
+    targetElement: editablePopoverElem,
+    keyNames: editableConfig.map((obj) => obj.keyName),
+    shouldSyncIntoUpdateElems: true,
+  });
+
+  // render html inside the edit popover
+  let remakeEditAreasElem = editablePopoverElem.querySelector('.remake-edit__edit-areas');
+  remakeEditAreasElem.innerHTML = generateRemakeEditAreas({ config: editableConfig });
+
+  // copy the layout
+  copyLayout({
+    sourceElem: firstMatchElem,
+    targetElem: editablePopoverElem,
+    dimensionsName: 'width',
+    xOffset: 0,
+    yOffset: 0,
+  });
+
+  // autosize textareas -- not sure why or even if this needs to be in a setTimeout
+  setTimeout(function() {
+    let textareas = Array.from(editablePopoverElem.querySelectorAll('textarea'));
+    textareas.forEach((el) => autosize(el));
+  });
+
+  // focus first focusable element
+  let firstFormInput = editablePopoverElem.querySelector('textarea, input');
+  if (firstFormInput) {
+    firstFormInput.focus();
+  }
+};

--- a/_remake/client-side/inputjs/editableAttribute.js
+++ b/_remake/client-side/inputjs/editableAttribute.js
@@ -1,11 +1,130 @@
-import { $ } from '../queryjs';
-import { forEachAttr, onAttributeEvent } from '../hummingbird/lib/dom';
-import { copyLayout } from '../copy-layout';
-import { getClosestElemWithKey, setValueForKeyName, getKeyNamesFromElem } from '../data-utilities';
-import { openEditCallback } from './callbacks';
-import { syncDataNextTick } from './syncData';
-import { showError } from '../common/show-error';
-import autosize from '../vendor/autosize';
+import {$} from "../queryjs";
+import {forEachAttr, onAttributeEvent} from "../hummingbird/lib/dom";
+import {copyLayout} from "../copy-layout";
+import {getClosestElemWithKey, setValueForKeyName, getKeyNamesFromElem} from "../data-utilities";
+import {syncDataNextTick} from "./syncData";
+import {showError} from "../common/show-error";
+import autosize from "../vendor/autosize";
+
+// USAGE EXAMPLES:
+// edit:example-key
+// edit:example-key:text
+// edit:example-key:textarea
+export const openEditCallback = matches => {
+  // matches: [{eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
+
+  // editableConfig: [{keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
+  let editableConfig = matches.map(
+    ({eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}) => {
+      let attributeParts = matchingAttribute.split(":");
+      // attributeParts could be:
+      // ["edit", "example-key"]
+      // ["edit", "example-key", "without-remove"]
+      // ["edit", "example-key", "textarea", "without-remove"]
+      // -> first two items are requireed, the last two are optional
+      let [_, keyName, ...otherOptions] = attributeParts;
+
+      let validRemoveOptions = ["with-remove", "without-remove", "with-erase"];
+      let validFormTypes = ["text", "textarea"];
+
+      // if `otherOptions` includes includes a valid remove option, use that. Otherwise, use default value.
+      let removeOption =
+        validRemoveOptions.find(str => otherOptions.includes(str)) || "with-remove";
+      // if `otherOptions` includes includes a valid form type option, use that. Otherwise, use default value.
+      let formType = validFormTypes.find(str => otherOptions.includes(str)) || "text";
+
+      return {
+        keyName,
+        formType,
+        removeOption,
+        eventType,
+        matchingElement,
+        matchingAttribute,
+        matchingPartialAttributeString,
+      };
+    }
+  );
+
+  // get first matching element for positioning popover
+  let firstMatch = editableConfig[0];
+  let firstMatchElem = firstMatch.matchingElement;
+  let firstMatchKeyName = firstMatch.keyName;
+  let firstMatchRemoveOption = firstMatch.removeOption;
+  let firstMatchTargetElem = getClosestElemWithKey({
+    elem: firstMatchElem,
+    keyName: firstMatchKeyName,
+  });
+
+  if (!firstMatchElem || !firstMatchKeyName || !firstMatchTargetElem) {
+    showError(
+      `Problem with the 'edit:' attribute on one of these elements:`,
+      matches.map(m => m.matchingElement)
+    );
+    return;
+  }
+
+  let editablePopoverElem = document.querySelector(".remake-edit");
+
+  // reset popover: remove old keys
+  removeObjectKeysFromElem({elem: editablePopoverElem});
+
+  // open popover
+  let hasRemove = firstMatchRemoveOption === "with-remove";
+  let hasErase = firstMatchRemoveOption === "with-erase";
+  editablePopoverElem.setAttribute(`temporary:key:remake-edit-popover`, "");
+  editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-remove`, "");
+  editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-erase`, "");
+  setValueForKeyName({elem: editablePopoverElem, keyName: "remake-edit-popover", value: "on"});
+  setValueForKeyName({
+    elem: editablePopoverElem,
+    keyName: "remake-edit-option-has-remove",
+    value: hasRemove ? "on" : "off",
+  });
+  setValueForKeyName({
+    elem: editablePopoverElem,
+    keyName: "remake-edit-option-has-erase",
+    value: hasErase ? "on" : "off",
+  });
+
+  // keep track of the source of the data on the popover element
+  $.data(editablePopoverElem, "source", firstMatchTargetElem);
+
+  // add object keys for storing data that's being edited in the popover
+  addObjectKeysToElem({elem: editablePopoverElem, config: editableConfig});
+
+  // sync data from the page into the popover
+  syncDataNextTick({
+    sourceElement: firstMatchElem,
+    targetElement: editablePopoverElem,
+    keyNames: editableConfig.map(obj => obj.keyName),
+    shouldSyncIntoUpdateElems: true,
+  });
+
+  // render html inside the edit popover
+  let remakeEditAreasElem = editablePopoverElem.querySelector(".remake-edit__edit-areas");
+  remakeEditAreasElem.innerHTML = generateRemakeEditAreas({config: editableConfig});
+
+  // copy the layout
+  copyLayout({
+    sourceElem: firstMatchElem,
+    targetElem: editablePopoverElem,
+    dimensionsName: "width",
+    xOffset: 0,
+    yOffset: 0,
+  });
+
+  // autosize textareas -- not sure why or even if this needs to be in a setTimeout
+  setTimeout(function() {
+    let textareas = Array.from(editablePopoverElem.querySelectorAll("textarea"));
+    textareas.forEach(el => autosize(el));
+  });
+
+  // focus first focusable element
+  let firstFormInput = editablePopoverElem.querySelector("textarea, input");
+  if (firstFormInput) {
+    firstFormInput.focus();
+  }
+};
 
 // USAGE EXAMPLES:
 // edit:example-key
@@ -13,30 +132,30 @@ import autosize from '../vendor/autosize';
 // edit:example-key:textarea
 export default function() {
   onAttributeEvent({
-    eventTypes: ['click'],
-    partialAttributeStrings: ['edit:'],
+    eventTypes: ["click"],
+    partialAttributeStrings: ["edit:"],
     groupMatchesIntoSingleCallback: true,
-    filterOutElemsInsideAncestor: '[disable-events]',
+    filterOutElemsInsideAncestor: "[disable-events]",
     callback: openEditCallback,
   });
 
   // sync data from popover into the page
-  $.on('submit', '[sync]', (event) => {
+  $.on("submit", "[sync]", event => {
     event.preventDefault();
-    let syncElement = event.currentTarget.closest('[sync]');
+    let syncElement = event.currentTarget.closest("[sync]");
     syncDataNextTick({
       sourceElement: syncElement,
-      targetElement: $.data(syncElement, 'source'),
+      targetElement: $.data(syncElement, "source"),
       keyNames: getKeyNamesFromElem(syncElement),
     });
   });
 
   // this was causing a bug before. i think the form was submitting when it shouldn't have.
-  $.on('click', ".remake-edit__button:not([type='submit'])", function(event) {
+  $.on("click", ".remake-edit__button:not([type='submit'])", function(event) {
     event.preventDefault();
   });
 
-  document.addEventListener('keydown', (event) => {
+  document.addEventListener("keydown", event => {
     // esc key
     if (event.keyCode === 27) {
       let turnedOnEditablePopover = document.querySelector('[key:remake-edit-popover="on"]');
@@ -44,45 +163,45 @@ export default function() {
       if (turnedOnEditablePopover) {
         setValueForKeyName({
           elem: turnedOnEditablePopover,
-          keyName: 'remake-edit-popover',
-          value: 'off',
+          keyName: "remake-edit-popover",
+          value: "off",
         });
       }
     }
   });
 }
 
-function removeObjectKeysFromElem({ elem }) {
+function removeObjectKeysFromElem({elem}) {
   let attributesToRemove = [];
   forEachAttr(elem, (attrName, attrValue) => {
-    if (attrName.startsWith('key:') || attrName.startsWith('temporary:key:')) {
+    if (attrName.startsWith("key:") || attrName.startsWith("temporary:key:")) {
       attributesToRemove.push(attrName);
     }
   });
   // this is outside the loop because you can't remove items from an array when you're looping through it
-  attributesToRemove.forEach((attrName) => elem.removeAttribute(attrName));
+  attributesToRemove.forEach(attrName => elem.removeAttribute(attrName));
 }
 
 // config: [{keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
-function addObjectKeysToElem({ elem, config }) {
-  config.forEach((obj) => {
-    elem.setAttribute(`temporary:key:${obj.keyName}`, '');
+function addObjectKeysToElem({elem, config}) {
+  config.forEach(obj => {
+    elem.setAttribute(`temporary:key:${obj.keyName}`, "");
   });
 }
 
 // config: [{keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
-function generateRemakeEditAreas({ config }) {
-  let outputHtml = '';
+function generateRemakeEditAreas({config}) {
+  let outputHtml = "";
 
   // formType can be "text" or "textarea" or something else that's not implemented yet
-  config.forEach(({ formType, keyName }) => {
+  config.forEach(({formType, keyName}) => {
     let formFieldHtml;
 
-    if (formType === 'text') {
+    if (formType === "text") {
       formFieldHtml = `<input class="remake-edit__input" update:${keyName} type="text">`;
     }
 
-    if (formType === 'textarea') {
+    if (formType === "textarea") {
       formFieldHtml = `<textarea class="remake-edit__textarea" update:${keyName}></textarea>`;
     }
 

--- a/_remake/client-side/inputjs/editableAttribute.js
+++ b/_remake/client-side/inputjs/editableAttribute.js
@@ -6,7 +6,7 @@ import { syncDataNextTick } from "./syncData";
 import { showError } from "../common/show-error";
 import autosize from '../vendor/autosize';
 
-// USAGE EXAMPLES: 
+// USAGE EXAMPLES:
 // edit:example-key
 // edit:example-key:text
 // edit:example-key:textarea
@@ -86,10 +86,10 @@ export default function () {
 
       // copy the layout
       copyLayout({
-        sourceElem: firstMatchElem, 
-        targetElem: editablePopoverElem, 
-        dimensionsName: "width", 
-        xOffset: 0, 
+        sourceElem: firstMatchElem,
+        targetElem: editablePopoverElem,
+        dimensionsName: "width",
+        xOffset: 0,
         yOffset: 0
       });
 
@@ -105,6 +105,104 @@ export default function () {
         firstFormInput.focus();
       }
 
+    }
+  });
+
+  onAttributeEvent({
+    eventTypes: ["click"],
+    partialAttributeStrings: ["delete:"],
+    groupMatchesIntoSingleCallback: true,
+    filterOutElemsInsideAncestor: "[disable-events]",
+    callback: (matches) => { // matches: [{eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
+      // editableConfig: [{keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
+      let editableConfig = matches.map(({eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}) => {
+        let attributeParts = matchingAttribute.split(":");
+        // attributeParts could be:
+        // ["edit", "example-key"]
+        // ["edit", "example-key", "without-remove"]
+        // ["edit", "example-key", "textarea", "without-remove"]
+        // -> first two items are requireed, the last two are optional
+        let [_, keyName, ...otherOptions] = attributeParts;
+
+        let validRemoveOptions = ["with-remove", "without-remove", "with-erase"];
+        let validFormTypes = ["text", "textarea"];
+
+        // if `otherOptions` includes includes a valid remove option, use that. Otherwise, use default value.
+        let removeOption = validRemoveOptions.find(str => otherOptions.includes(str)) || "with-remove";
+        // if `otherOptions` includes includes a valid form type option, use that. Otherwise, use default value.
+        let formType = validFormTypes.find(str => otherOptions.includes(str)) || "text";
+
+        return {keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString};
+      });
+
+      // get first matching element for positioning popover
+      let firstMatch = editableConfig[0];
+      let firstMatchElem = firstMatch.matchingElement;
+      let firstMatchKeyName = firstMatch.keyName;
+      let firstMatchRemoveOption = firstMatch.removeOption;
+
+      let firstMatchTargetElem = getClosestElemWithKey({elem: firstMatchElem, keyName: firstMatchKeyName});
+
+      if (!firstMatchElem || !firstMatchKeyName || !firstMatchTargetElem) {
+        showError(`Problem with the 'edit:' attribute on one of these elements:`, matches.map(m => m.matchingElement));
+        return;
+      }
+
+      let editablePopoverElem = document.querySelector(".remake-edit");
+
+      // reset popover: remove old keys
+      removeObjectKeysFromElem({elem: editablePopoverElem});
+
+      // open popover
+      let hasRemove = firstMatchRemoveOption === "with-remove";
+      let hasErase = firstMatchRemoveOption === "with-erase";
+      editablePopoverElem.setAttribute(`temporary:key:remake-edit-popover`, "");
+      editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-remove`, "");
+      editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-erase`, "");
+      setValueForKeyName({elem: editablePopoverElem, keyName: "remake-edit-popover", value: "on"});
+      setValueForKeyName({elem: editablePopoverElem, keyName: "remake-edit-option-has-remove", value: hasRemove ? "on" : "off"});
+      setValueForKeyName({elem: editablePopoverElem, keyName: "remake-edit-option-has-erase", value: hasErase ? "on" : "off"});
+
+      // keep track of the source of the data on the popover element
+      $.data(editablePopoverElem, "source", firstMatchTargetElem);
+
+      // add object keys for storing data that's being edited in the popover
+      addObjectKeysToElem({elem: editablePopoverElem, config: editableConfig});
+
+      // sync data from the page into the popover
+      syncDataNextTick({
+        sourceElement: firstMatchElem,
+        targetElement: editablePopoverElem,
+        keyNames: editableConfig.map(obj => obj.keyName),
+        shouldSyncIntoUpdateElems: true
+      });
+
+      // render html inside the edit popover
+      let remakeEditAreasElem = editablePopoverElem.querySelector(".remake-edit__edit-areas");
+      remakeEditAreasElem.innerHTML = generateRemakeEditAreas({config: editableConfig});
+
+      // copy the layout
+      copyLayout({
+        sourceElem: firstMatchElem,
+        targetElem: editablePopoverElem,
+        dimensionsName: "width",
+        xOffset: 0,
+        yOffset: 0
+      });
+
+      // autosize textareas -- not sure why or even if this needs to be in a setTimeout
+      setTimeout(function () {
+        let textareas = Array.from(editablePopoverElem.querySelectorAll("textarea"));
+        textareas.forEach(el => autosize(el));
+      });
+
+      // focus first focusable element
+      let firstFormInput = editablePopoverElem.querySelector("textarea, input")
+      if (firstFormInput) {
+        firstFormInput.focus();
+      }
+
+      document.querySelector('[remove]').click();
     }
   });
 
@@ -128,7 +226,7 @@ export default function () {
     // esc key
     if (event.keyCode === 27) {
       let turnedOnEditablePopover = document.querySelector('[key:remake-edit-popover="on"]');
-      
+
       if (turnedOnEditablePopover) {
         setValueForKeyName({elem: turnedOnEditablePopover, keyName: "remake-edit-popover", value: "off"});
       }
@@ -175,5 +273,3 @@ function generateRemakeEditAreas ({config}) {
 
   return outputHtml;
 }
-
-

--- a/_remake/client-side/inputjs/editableAttribute.js
+++ b/_remake/client-side/inputjs/editableAttribute.js
@@ -2,171 +2,87 @@ import { $ } from '../queryjs';
 import { forEachAttr, onAttributeEvent } from '../hummingbird/lib/dom';
 import { copyLayout } from '../copy-layout';
 import { getClosestElemWithKey, setValueForKeyName, getKeyNamesFromElem } from '../data-utilities';
-import { syncDataNextTick } from "./syncData";
-import { showError } from "../common/show-error";
+import { openEditCallback } from './callbacks';
+import { syncDataNextTick } from './syncData';
+import { showError } from '../common/show-error';
 import autosize from '../vendor/autosize';
 
-// USAGE EXAMPLES: 
+// USAGE EXAMPLES:
 // edit:example-key
 // edit:example-key:text
 // edit:example-key:textarea
-export default function () {
+export default function() {
   onAttributeEvent({
-    eventTypes: ["click"],
-    partialAttributeStrings: ["edit:"],
+    eventTypes: ['click'],
+    partialAttributeStrings: ['edit:'],
     groupMatchesIntoSingleCallback: true,
-    filterOutElemsInsideAncestor: "[disable-events]",
-    callback: (matches) => { // matches: [{eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
-
-      // editableConfig: [{keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
-      let editableConfig = matches.map(({eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}) => {
-        let attributeParts = matchingAttribute.split(":");
-        // attributeParts could be:
-        // ["edit", "example-key"]
-        // ["edit", "example-key", "without-remove"]
-        // ["edit", "example-key", "textarea", "without-remove"]
-        // -> first two items are requireed, the last two are optional
-        let [_, keyName, ...otherOptions] = attributeParts;
-
-        let validRemoveOptions = ["with-remove", "without-remove", "with-erase"];
-        let validFormTypes = ["text", "textarea"];
-
-        // if `otherOptions` includes includes a valid remove option, use that. Otherwise, use default value.
-        let removeOption = validRemoveOptions.find(str => otherOptions.includes(str)) || "with-remove";
-        // if `otherOptions` includes includes a valid form type option, use that. Otherwise, use default value.
-        let formType = validFormTypes.find(str => otherOptions.includes(str)) || "text";
-
-        return {keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString};
-      });
-
-      // get first matching element for positioning popover
-      let firstMatch = editableConfig[0];
-      let firstMatchElem = firstMatch.matchingElement;
-      let firstMatchKeyName = firstMatch.keyName;
-      let firstMatchRemoveOption = firstMatch.removeOption;
-      let firstMatchTargetElem = getClosestElemWithKey({elem: firstMatchElem, keyName: firstMatchKeyName});
-
-      if (!firstMatchElem || !firstMatchKeyName || !firstMatchTargetElem) {
-        showError(`Problem with the 'edit:' attribute on one of these elements:`, matches.map(m => m.matchingElement));
-        return;
-      }
-
-      let editablePopoverElem = document.querySelector(".remake-edit");
-
-      // reset popover: remove old keys
-      removeObjectKeysFromElem({elem: editablePopoverElem});
-
-      // open popover
-      let hasRemove = firstMatchRemoveOption === "with-remove";
-      let hasErase = firstMatchRemoveOption === "with-erase";
-      editablePopoverElem.setAttribute(`temporary:key:remake-edit-popover`, "");
-      editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-remove`, "");
-      editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-erase`, "");
-      setValueForKeyName({elem: editablePopoverElem, keyName: "remake-edit-popover", value: "on"});
-      setValueForKeyName({elem: editablePopoverElem, keyName: "remake-edit-option-has-remove", value: hasRemove ? "on" : "off"});
-      setValueForKeyName({elem: editablePopoverElem, keyName: "remake-edit-option-has-erase", value: hasErase ? "on" : "off"});
-
-      // keep track of the source of the data on the popover element
-      $.data(editablePopoverElem, "source", firstMatchTargetElem);
-
-      // add object keys for storing data that's being edited in the popover
-      addObjectKeysToElem({elem: editablePopoverElem, config: editableConfig});
-
-      // sync data from the page into the popover
-      syncDataNextTick({
-        sourceElement: firstMatchElem,
-        targetElement: editablePopoverElem,
-        keyNames: editableConfig.map(obj => obj.keyName),
-        shouldSyncIntoUpdateElems: true
-      });
-
-      // render html inside the edit popover
-      let remakeEditAreasElem = editablePopoverElem.querySelector(".remake-edit__edit-areas");
-      remakeEditAreasElem.innerHTML = generateRemakeEditAreas({config: editableConfig});
-
-      // copy the layout
-      copyLayout({
-        sourceElem: firstMatchElem, 
-        targetElem: editablePopoverElem, 
-        dimensionsName: "width", 
-        xOffset: 0, 
-        yOffset: 0
-      });
-
-      // autosize textareas -- not sure why or even if this needs to be in a setTimeout
-      setTimeout(function () {
-        let textareas = Array.from(editablePopoverElem.querySelectorAll("textarea"));
-        textareas.forEach(el => autosize(el));
-      });
-
-      // focus first focusable element
-      let firstFormInput = editablePopoverElem.querySelector("textarea, input")
-      if (firstFormInput) {
-        firstFormInput.focus();
-      }
-
-    }
+    filterOutElemsInsideAncestor: '[disable-events]',
+    callback: openEditCallback,
   });
 
   // sync data from popover into the page
-  $.on("submit", "[sync]", (event) => {
+  $.on('submit', '[sync]', (event) => {
     event.preventDefault();
-    let syncElement = event.currentTarget.closest("[sync]");
+    let syncElement = event.currentTarget.closest('[sync]');
     syncDataNextTick({
       sourceElement: syncElement,
-      targetElement: $.data(syncElement, "source"),
-      keyNames: getKeyNamesFromElem(syncElement)
+      targetElement: $.data(syncElement, 'source'),
+      keyNames: getKeyNamesFromElem(syncElement),
     });
   });
 
   // this was causing a bug before. i think the form was submitting when it shouldn't have.
-  $.on("click", ".remake-edit__button:not([type='submit'])", function (event) {
+  $.on('click', ".remake-edit__button:not([type='submit'])", function(event) {
     event.preventDefault();
   });
 
-  document.addEventListener("keydown", event => {
+  document.addEventListener('keydown', (event) => {
     // esc key
     if (event.keyCode === 27) {
       let turnedOnEditablePopover = document.querySelector('[key:remake-edit-popover="on"]');
-      
+
       if (turnedOnEditablePopover) {
-        setValueForKeyName({elem: turnedOnEditablePopover, keyName: "remake-edit-popover", value: "off"});
+        setValueForKeyName({
+          elem: turnedOnEditablePopover,
+          keyName: 'remake-edit-popover',
+          value: 'off',
+        });
       }
     }
   });
 }
 
-function removeObjectKeysFromElem ({elem}) {
+function removeObjectKeysFromElem({ elem }) {
   let attributesToRemove = [];
   forEachAttr(elem, (attrName, attrValue) => {
-    if (attrName.startsWith("key:") || attrName.startsWith("temporary:key:")) {
+    if (attrName.startsWith('key:') || attrName.startsWith('temporary:key:')) {
       attributesToRemove.push(attrName);
     }
   });
   // this is outside the loop because you can't remove items from an array when you're looping through it
-  attributesToRemove.forEach(attrName => elem.removeAttribute(attrName));
+  attributesToRemove.forEach((attrName) => elem.removeAttribute(attrName));
 }
 
 // config: [{keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
-function addObjectKeysToElem ({elem, config}) {
-  config.forEach(obj => {
-    elem.setAttribute(`temporary:key:${obj.keyName}`, "")
+function addObjectKeysToElem({ elem, config }) {
+  config.forEach((obj) => {
+    elem.setAttribute(`temporary:key:${obj.keyName}`, '');
   });
 }
 
 // config: [{keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
-function generateRemakeEditAreas ({config}) {
-  let outputHtml = "";
+function generateRemakeEditAreas({ config }) {
+  let outputHtml = '';
 
   // formType can be "text" or "textarea" or something else that's not implemented yet
-  config.forEach(({formType, keyName}) => {
+  config.forEach(({ formType, keyName }) => {
     let formFieldHtml;
 
-    if (formType === "text") {
+    if (formType === 'text') {
       formFieldHtml = `<input class="remake-edit__input" update:${keyName} type="text">`;
     }
 
-    if (formType === "textarea") {
+    if (formType === 'textarea') {
       formFieldHtml = `<textarea class="remake-edit__textarea" update:${keyName}></textarea>`;
     }
 
@@ -175,5 +91,3 @@ function generateRemakeEditAreas ({config}) {
 
   return outputHtml;
 }
-
-

--- a/_remake/client-side/inputjs/editableAttribute.js
+++ b/_remake/client-side/inputjs/editableAttribute.js
@@ -6,7 +6,7 @@ import { syncDataNextTick } from "./syncData";
 import { showError } from "../common/show-error";
 import autosize from '../vendor/autosize';
 
-// USAGE EXAMPLES:
+// USAGE EXAMPLES: 
 // edit:example-key
 // edit:example-key:text
 // edit:example-key:textarea
@@ -86,10 +86,10 @@ export default function () {
 
       // copy the layout
       copyLayout({
-        sourceElem: firstMatchElem,
-        targetElem: editablePopoverElem,
-        dimensionsName: "width",
-        xOffset: 0,
+        sourceElem: firstMatchElem, 
+        targetElem: editablePopoverElem, 
+        dimensionsName: "width", 
+        xOffset: 0, 
         yOffset: 0
       });
 
@@ -105,104 +105,6 @@ export default function () {
         firstFormInput.focus();
       }
 
-    }
-  });
-
-  onAttributeEvent({
-    eventTypes: ["click"],
-    partialAttributeStrings: ["delete:"],
-    groupMatchesIntoSingleCallback: true,
-    filterOutElemsInsideAncestor: "[disable-events]",
-    callback: (matches) => { // matches: [{eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
-      // editableConfig: [{keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}]
-      let editableConfig = matches.map(({eventType, matchingElement, matchingAttribute, matchingPartialAttributeString}) => {
-        let attributeParts = matchingAttribute.split(":");
-        // attributeParts could be:
-        // ["edit", "example-key"]
-        // ["edit", "example-key", "without-remove"]
-        // ["edit", "example-key", "textarea", "without-remove"]
-        // -> first two items are requireed, the last two are optional
-        let [_, keyName, ...otherOptions] = attributeParts;
-
-        let validRemoveOptions = ["with-remove", "without-remove", "with-erase"];
-        let validFormTypes = ["text", "textarea"];
-
-        // if `otherOptions` includes includes a valid remove option, use that. Otherwise, use default value.
-        let removeOption = validRemoveOptions.find(str => otherOptions.includes(str)) || "with-remove";
-        // if `otherOptions` includes includes a valid form type option, use that. Otherwise, use default value.
-        let formType = validFormTypes.find(str => otherOptions.includes(str)) || "text";
-
-        return {keyName, formType, removeOption, eventType, matchingElement, matchingAttribute, matchingPartialAttributeString};
-      });
-
-      // get first matching element for positioning popover
-      let firstMatch = editableConfig[0];
-      let firstMatchElem = firstMatch.matchingElement;
-      let firstMatchKeyName = firstMatch.keyName;
-      let firstMatchRemoveOption = firstMatch.removeOption;
-
-      let firstMatchTargetElem = getClosestElemWithKey({elem: firstMatchElem, keyName: firstMatchKeyName});
-
-      if (!firstMatchElem || !firstMatchKeyName || !firstMatchTargetElem) {
-        showError(`Problem with the 'edit:' attribute on one of these elements:`, matches.map(m => m.matchingElement));
-        return;
-      }
-
-      let editablePopoverElem = document.querySelector(".remake-edit");
-
-      // reset popover: remove old keys
-      removeObjectKeysFromElem({elem: editablePopoverElem});
-
-      // open popover
-      let hasRemove = firstMatchRemoveOption === "with-remove";
-      let hasErase = firstMatchRemoveOption === "with-erase";
-      editablePopoverElem.setAttribute(`temporary:key:remake-edit-popover`, "");
-      editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-remove`, "");
-      editablePopoverElem.setAttribute(`temporary:key:remake-edit-option-has-erase`, "");
-      setValueForKeyName({elem: editablePopoverElem, keyName: "remake-edit-popover", value: "on"});
-      setValueForKeyName({elem: editablePopoverElem, keyName: "remake-edit-option-has-remove", value: hasRemove ? "on" : "off"});
-      setValueForKeyName({elem: editablePopoverElem, keyName: "remake-edit-option-has-erase", value: hasErase ? "on" : "off"});
-
-      // keep track of the source of the data on the popover element
-      $.data(editablePopoverElem, "source", firstMatchTargetElem);
-
-      // add object keys for storing data that's being edited in the popover
-      addObjectKeysToElem({elem: editablePopoverElem, config: editableConfig});
-
-      // sync data from the page into the popover
-      syncDataNextTick({
-        sourceElement: firstMatchElem,
-        targetElement: editablePopoverElem,
-        keyNames: editableConfig.map(obj => obj.keyName),
-        shouldSyncIntoUpdateElems: true
-      });
-
-      // render html inside the edit popover
-      let remakeEditAreasElem = editablePopoverElem.querySelector(".remake-edit__edit-areas");
-      remakeEditAreasElem.innerHTML = generateRemakeEditAreas({config: editableConfig});
-
-      // copy the layout
-      copyLayout({
-        sourceElem: firstMatchElem,
-        targetElem: editablePopoverElem,
-        dimensionsName: "width",
-        xOffset: 0,
-        yOffset: 0
-      });
-
-      // autosize textareas -- not sure why or even if this needs to be in a setTimeout
-      setTimeout(function () {
-        let textareas = Array.from(editablePopoverElem.querySelectorAll("textarea"));
-        textareas.forEach(el => autosize(el));
-      });
-
-      // focus first focusable element
-      let firstFormInput = editablePopoverElem.querySelector("textarea, input")
-      if (firstFormInput) {
-        firstFormInput.focus();
-      }
-
-      document.querySelector('[remove]').click();
     }
   });
 
@@ -226,7 +128,7 @@ export default function () {
     // esc key
     if (event.keyCode === 27) {
       let turnedOnEditablePopover = document.querySelector('[key:remake-edit-popover="on"]');
-
+      
       if (turnedOnEditablePopover) {
         setValueForKeyName({elem: turnedOnEditablePopover, keyName: "remake-edit-popover", value: "off"});
       }
@@ -273,3 +175,5 @@ function generateRemakeEditAreas ({config}) {
 
   return outputHtml;
 }
+
+


### PR DESCRIPTION
Currently creating a new item doesn't open up an edit prompt, meaning the user has to manually go to the newest element and edit it manually.

With this PR, It will be possible to allow the edit prompt to open automatically on new item creation. By default, current functionality is maintained. Adding a `edit` attribute (Example: `<button new:prop:open-popup></button>` will open up a edit prompt.